### PR TITLE
Fix: Configure Dapper for snake_case to PascalCase mapping

### DIFF
--- a/keijibanapi/Program.cs
+++ b/keijibanapi/Program.cs
@@ -13,6 +13,9 @@ using keijibanapi.Services;
 using keijibanapi.Validators;
 
 
+// Dapperでsnake_caseとPascalCaseを自動マッピングする設定
+Dapper.DefaultTypeMap.MatchNamesWithUnderscores = true;
+
 SqlMapper.AddTypeHandler(new StringTypeHandler<EmergencyPriority>());
 SqlMapper.AddTypeHandler(new StringTypeHandler<Priority>());
 SqlMapper.AddTypeHandler(new StringTypeHandler<ActionStatus>());

--- a/keijibanapi/Repositories/EmergencyNoticeRepository.cs
+++ b/keijibanapi/Repositories/EmergencyNoticeRepository.cs
@@ -24,9 +24,9 @@ namespace keijibanapi.Repositories
         public async Task<IEnumerable<EmergencyNotice>> GetAllWithDepartmentsAsync()
         {
             const string noticesSql = @"
-                SELECT id, priority, notice_type as NoticeType, notice_content as NoticeContent, is_all_departments,
-                       is_active, created_at as CreatedAt, updated_at as UpdatedAt, created_by_department_id as CreatedByDepartmentId,
-                       target_department_names as TargetDepartmentNames
+                SELECT id, priority, notice_type, notice_content, is_all_departments,
+                       is_active, created_at, updated_at, created_by_department_id,
+                       target_department_names
                 FROM v_emergency_notices_with_departments
                 ORDER BY created_at DESC, is_active DESC LIMIT 30";
 


### PR DESCRIPTION
This commit resolves an issue where Dapper was failing to map database columns with snake_case names to C# properties with PascalCase names, resulting in null or default values in the mapped objects.

The root cause was the absence of a global Dapper configuration to handle this naming convention difference.

Changes:
- Added `Dapper.DefaultTypeMap.MatchNamesWithUnderscores = true;` to `Program.cs` to enable automatic mapping across the application.
- Removed redundant SQL aliases from `EmergencyNoticeRepository.cs` that were used as a manual workaround for this issue.

This change fixes the mapping for all Dapper queries and simplifies the data access code.